### PR TITLE
Fix missing KnContact child for KnPerson

### DIFF
--- a/src/Core/Entity/Plugin/KnPerson.php
+++ b/src/Core/Entity/Plugin/KnPerson.php
@@ -49,8 +49,9 @@ class KnPerson extends Relation {
    */
   public function isValidChild(EntityInterface $entity) {
     switch ($entity->getType()) {
-      case 'KnBankAccount':
-        return TRUE;
+	  case 'KnBankAccount':
+	  case 'KnContact':
+	    return TRUE;
     }
 
     return parent::isValidChild($entity);

--- a/tests/src/Core/Entity/Plugin/KnPersonTest.php
+++ b/tests/src/Core/Entity/Plugin/KnPersonTest.php
@@ -27,6 +27,7 @@ class KnPersonTest extends PluginTestBase {
     $this->assertTrue($this->entity->isValidChild(new Entity([], 'KnBankAccount')));
     $this->assertTrue($this->entity->isValidChild(new Entity([], 'KnBasicAddressAdr')));
     $this->assertTrue($this->entity->isValidChild(new Entity([], 'KnBasicAddressPad')));
+	$this->assertTrue($this->entity->isValidChild(new Entity([], 'KnContact')));
   }
 
   /**


### PR DESCRIPTION
This pull request fixes an issue where KnPerson objects were missing their corresponding KnContact child entity.

[documentation reference](https://docs.afas.help/apidoc/nl/Organisaties%20en%20personen#put-/connectors/KnSalesRelationPer)